### PR TITLE
Create empty viewState when constructing state object

### DIFF
--- a/native/PluginProcessor.cpp
+++ b/native/PluginProcessor.cpp
@@ -78,6 +78,7 @@ EffectsPluginProcessor::EffectsPluginProcessor()
         // Update our state object with the default parameter value
         state.insert_or_assign(paramId, defValue);
     }
+    state.insert_or_assign("viewState", "");
 }
 
 EffectsPluginProcessor::~EffectsPluginProcessor()


### PR DESCRIPTION
When restoring the host state, the code checks if that property exists on 'state' before it assigns it into the state.

This means you need a default value for 'viewState' in state