### PR TITLE
Prevent runtime being swapped out on the message thread whilst it's in use on the audio thread

### DIFF
--- a/native/PluginProcessor.cpp
+++ b/native/PluginProcessor.cpp
@@ -259,8 +259,6 @@ void EffectsPluginProcessor::handleAsyncUpdate()
     // First things first, we check the flag to identify if we should initialize the Elementary
     // runtime and engine.
     if (shouldInitialize.exchange(false)) {
-        // TODO: This is definitely not thread-safe! It could delete a Runtime instance while
-        // the real-time thread is using it. Depends on when the host will call prepareToPlay.
         runtime = std::make_unique<elem::Runtime<float>>(lastKnownSampleRate, lastKnownBlockSize);
         initJavaScriptEngine();
         runtimeSwapRequired.store(false);

--- a/native/PluginProcessor.h
+++ b/native/PluginProcessor.h
@@ -97,6 +97,7 @@ private:
     static std::string serialize(const std::string&function, const choc::value::Value&data, const juce::String&replacementChar = "%");
 
     //==============================================================================
+    std::atomic<bool> runtimeSwapRequired { false };
     std::atomic<bool> shouldInitialize { false };
     double lastKnownSampleRate = 0;
     int lastKnownBlockSize = 0;


### PR DESCRIPTION
Hopefully this will prevent the runtime being reset if its currently in use on the audio thread.
This may cause a buffer or two of silence when block size and / or sample rate changes, but that's better than a crash.